### PR TITLE
feat: Redis 클라이언트 통합 및 Access Token Refresh 로직 구현

### DIFF
--- a/server/config/redis.js
+++ b/server/config/redis.js
@@ -1,0 +1,30 @@
+const { createClient } = require('redis');
+require('dotenv').config();
+
+const redisClient = createClient({
+  username: 'default',
+  password: process.env.REDIS_PASSWORD,
+  socket: {
+    host: process.env.REDIS_HOST,
+    port: Number(process.env.REDIS_PORT),
+  },
+});
+
+redisClient.on('error', (err) => {
+  console.error('❌ Redis Client Error:', err);
+});
+
+const connectRedis = async () => {
+  try {
+    await redisClient.connect();
+    console.log('✅ Redis connected successfully');
+  } catch (err) {
+    console.error('❌ Redis connection failed:', err);
+    process.exit(1);
+  }
+};
+
+module.exports = {
+  redisClient,
+  connectRedis,
+};

--- a/server/index.js
+++ b/server/index.js
@@ -3,16 +3,27 @@ const cors = require('cors');
 const routes = require('./routes');
 const connectDB = require('./config/db');
 const errorHandler = require('./middlewares/errorHandler');
+const { connectRedis } = require('./config/redis');
 
 const app = express();
 const PORT = process.env.PORT || 5000;
 
 // 미들웨어 설정
-app.use(cors());
+app.use(
+  cors({
+    origin: [
+      'http://localhost:3000',
+      'https://web-react-momentum2-0-client-m6m4lqe82f54a44f.sel4.cloudtype.app/',
+    ],
+    credentials: true,
+  }),
+);
+
 app.use(express.json());
 
 // MongoDB 연결
 connectDB();
+connectRedis();
 
 // 라우트 설정
 app.use('/api', routes); // 모든 라우트를 /api에 연결

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,7 +16,8 @@
         "express-rate-limit": "^7.5.0",
         "jsonwebtoken": "^9.0.2",
         "korean-regexp": "^1.0.13",
-        "mongoose": "^8.9.5"
+        "mongoose": "^8.9.5",
+        "redis": "^5.5.6"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -25,6 +26,61 @@
       "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.5.6.tgz",
+      "integrity": "sha512-bNR3mxkwtfuCxNOzfV8B3R5zA1LiN57EH6zK4jVBIgzMzliNuReZXBFGnXvsi80/SYohajn78YdpYI+XNpqL+A==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.5.6"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.5.6.tgz",
+      "integrity": "sha512-M3Svdwt6oSfyfQdqEr0L2HOJH2vK7GgCFx1NfAQvpWAT4+ljoT1L5S5cKT3dA9NJrxrOPDkdoTPWJnIrGCOcmw==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.5.6.tgz",
+      "integrity": "sha512-AIsoe3SsGQagqAmSQHaqxEinm5oCWr7zxPWL90kKaEdLJ+zw8KBznf2i9oK0WUFP5pFssSQUXqnscQKe2amfDQ==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.5.6"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.5.6.tgz",
+      "integrity": "sha512-JSqasYqO0mVcHL7oxvbySRBBZYRYhFl3W7f0Da7BW8M/r0Z9wCiVrdjnN4/mKBpWZkoJT/iuisLUdPGhpKxBew==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.5.6"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.5.6.tgz",
+      "integrity": "sha512-jkpcgq3NOI3TX7xEAJ3JgesJTxAx7k0m6lNxNsYdEM8KOl+xj7GaB/0CbLkoricZDmFSEAz7ClA1iK9XkGHf+Q==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.5.6"
       }
     },
     "node_modules/@types/webidl-conversions": {
@@ -131,6 +187,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/content-disposition": {
@@ -884,6 +948,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/redis": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.5.6.tgz",
+      "integrity": "sha512-hbpqBfcuhWHOS9YLNcXcJ4akNr7HFX61Dq3JuFZ9S7uU7C7kvnzuH2PDIXOP62A3eevvACoG8UacuXP3N07xdg==",
+      "dependencies": {
+        "@redis/bloom": "5.5.6",
+        "@redis/client": "5.5.6",
+        "@redis/json": "5.5.6",
+        "@redis/search": "5.5.6",
+        "@redis/time-series": "5.5.6"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/safe-buffer": {

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "express-rate-limit": "^7.5.0",
     "jsonwebtoken": "^9.0.2",
     "korean-regexp": "^1.0.13",
-    "mongoose": "^8.9.5"
+    "mongoose": "^8.9.5",
+    "redis": "^5.5.6"
   }
 }


### PR DESCRIPTION
📌 개요
Redis 클라이언트를 프로젝트에 통합하고, Axios 인터셉터를 이용해 Access Token 만료 시 자동으로 Refresh Token을 사용하여 갱신하는 로직을 구현했습니다.

✨ 주요 변경사항
1. server/config/redis.js: Redis 클라이언트 생성 및 연결 로직 추가

2. server/index.js: 서버 실행 시 Redis 연결 로직 적용

3. client/src/api/api.js: Axios response interceptor에 Access Token 자동 갱신 로직 구현
> 401 응답 시 /user/refresh 엔드포인트 호출
> 새로운 Access Token과 Refresh Token을 localStorage에 저장
> Authorization 헤더 갱신 후 요청 재시도 처리

🧩 이후 개발 계획
1. user.service.js에 Refresh Token 로테이션 로직 추가
> 기존 Refresh Token 폐기 및 새로운 Refresh Token 발급
> Redis에 토큰 유효성 저장 및 관리

2. /user/logout API 구현

> 로그아웃 시 Redis에서 Refresh Token 제거

3. 클라이언트 로그인/로그아웃 상태 관리 로직 개선

> Redux에서 토큰 저장 및 삭제 처리

✅ 테스트
1. 로컬 환경에서 Access Token 만료 후 Refresh 동작 테스트 완료
2. Redis에 연결 및 set/get 동작 확인
3. 기본 API 요청 정상 동작 확인

📝 참고사항
.env 파일에 Redis 환경 변수 설정 필요
npm install로 redis 패키지 설치 필요